### PR TITLE
Few fixes that were causing errors in Protege

### DIFF
--- a/dicom_ontology.ttl
+++ b/dicom_ontology.ttl
@@ -5,6 +5,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix nidm: <http://purl.org/nidash/nidm#> .
+@prefix dicom: <http://purl.org/nidash/dicom#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix nlx: <http://uri.neuinfo.org/nif/nifstd/> .

--- a/dicom_ontology.ttl
+++ b/dicom_ontology.ttl
@@ -13,7 +13,7 @@
 
 #http://purl.org/nidash/dicom# rdf:type owl:Ontology .
 
-rdf:type owl:Ontology .
+[rdf:type owl:Ontology .]
 
 
 #################################################################

--- a/dicom_ontology.ttl
+++ b/dicom_ontology.ttl
@@ -14,7 +14,7 @@
 
 #http://purl.org/nidash/dicom# rdf:type owl:Ontology .
 
-[rdf:type owl:Ontology .]
+[rdf:type owl:Ontology .] .
 
 
 #################################################################


### PR DESCRIPTION
Hi @khelm,

As discussed by email, this PR fixes a few bugs in the DICOM ontology that were causing errors when loading the document with Protege:
 - A blank node (defined using squared brackets, [more info](https://www.w3.org/TR/sparql11-query/#QSynBlankNodes)) was missing in the statement `rdf:type owl:Ontology .` 
 - Definition of the `dicom` prefix was missing.

There are still remaining issues but I think those should be easier to debug. Note that to get a meaningful error message in Protege, you need to navigate to the tab named "TurtleOntologyParser" (I have only discovered this now so I thought that could be useful if you did not know about it already).

Currently I get the following error: 
![screen shot 2017-09-12 at 16 02 42](https://user-images.githubusercontent.com/5374264/30333047-e28ad806-97d3-11e7-968b-1c764d702972.png) which could be due to the missing colon at the end of the `nlx_151278` prefix in ` owl:sameAs nlx_151278  ;` (should be `owl:sameAs nlx_151278:  ;`).

Is this enough to get you going? Let me know if you need help to debug further.
