### PR TITLE
rm_base

### DIFF
--- a/dicom_ontology_nlx.owl
+++ b/dicom_ontology_nlx.owl
@@ -11,7 +11,6 @@
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix dicom: <http://purl.org/nidash/dicom#> .
-@base <http://www.w3.org/2002/07/owl#> .
 
 
 


### PR DESCRIPTION
Removed the @base statement as a temporary fix for the issue of some rdf parsers not liking the '#' at the end of the base URI.